### PR TITLE
Revert "updated go.mod to replace ghedo module with aporeto module (#2)"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,4 @@
-module github.com/aporeto-inc/gopkt
-
-replace github.com/ghedo/go.pkt => github.com/aporeto-inc/gopkt
+module github.com/ghedo/go.pkt
 
 require (
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815


### PR DESCRIPTION
This reverts commit 1af745e7e4c1cf2778e55df3b3628bc6f5a869aa.

We should leave the master branch `go.mod` file to always refer to `github.com/ghedo/go-pkt` so that we do not mistakenly push this local needed change to any  upstream PRs. The change we need to the module name will be put on the branch called `go-mod` and this is the branch that should be referenced from any import statements in Aporeto code as 

`import "github.com/aporeto-inc/go-pkt"`

and in go.mod:

```
    github.com/aporeto-inc/gopkt go-mod
```
then run the `go mod download` tool.  It will download this branch and replace the branch name with a pseudo-version, date and sha hash like this: 
```
    github.com/aporeto-inc/gopkt v0.0.0-20200224231434-5490d8ecedcc
```

The `go-mod` branch has the needed changes to the `go.mod` file
https://github.com/aporeto-inc/gopkt/blob/go-mod/go.mod

And the `go-mod` branch should never be merged to master. 